### PR TITLE
Make `Version::license` optional

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -153,7 +153,7 @@ pub struct Version {
     /// Whether this version was yanked
     pub yanked: bool,
     /// The primary license of the crate
-    pub license: String,
+    pub license: Option<String>,
     /// When the crate was created
     #[serde(deserialize_with = "time02_parse_timestamp")]
     pub created_at: time::OffsetDateTime,


### PR DESCRIPTION
The license field in the API response can be `null`.

The `hyper` crate is "not found" in online mode because of this.