### PR TITLE
Improve crate version timestamp parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ home = "0.5.9"
 serde = { version = "1.0.197", features = [ "derive" ] }
 tar = "0.4.40"
 yansi = "0.5.1"
-time = { version = "0.3.34", features = [ "macros", "formatting", "parsing" ] }
+time = { version = "0.3.34", features = [ "macros", "formatting", "parsing", "serde" ] }
 pico-args = "0.5.0"
 serde_json = "1.0.114"

--- a/src/client.rs
+++ b/src/client.rs
@@ -155,10 +155,7 @@ pub struct Version {
     /// The primary license of the crate
     pub license: Option<String>,
     /// When the crate was created
-    #[serde(
-        deserialize_with = "time03_parse_timestamp",
-        serialize_with = "time03_format_timestamp"
-    )]
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: time::OffsetDateTime,
 
     dl_path: String,
@@ -196,37 +193,6 @@ impl Version {
             whole_seconds => "second"
         }
     }
-}
-
-pub fn time03_parse_timestamp<'de, D>(deser: D) -> Result<time::OffsetDateTime, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error as _;
-    use serde::Deserialize as _;
-
-    const FORMAT: &[FormatItem<'static>] = time::macros::format_description!(
-        "[year]-[month]-[day]T\
-        [hour]:[minute]:[second].[subsecond digits:6]\
-        [offset_hour sign:mandatory]:[offset_minute]"
-    );
-
-    let s = <std::borrow::Cow<'_, str>>::deserialize(deser)?;
-    time::OffsetDateTime::parse(&s, &FORMAT).map_err(D::Error::custom)
-}
-
-pub fn time03_format_timestamp<S>(
-    time: &time::OffsetDateTime,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: ::serde::Serializer,
-{
-    use serde::ser::Error as _;
-    use serde::ser::Serialize as _;
-    time.format(&Version::FMT)
-        .map_err(S::Error::custom)?
-        .serialize(serializer)
 }
 
 pub mod json {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn lookup(pkg_id: &PkgId, client: &Option<Client>, is_local: bool) -> anyhow
                 Some(semver) => client.get_version(name, semver),
                 None => client.get_latest(name),
             }
-            .map_err(|_| cannot_find(pkg_id))?;
+            .map_err(|_err| cannot_find(pkg_id))?;
 
             Ok(Lookup::Partial(pkg))
         }


### PR DESCRIPTION
As mentioned in #75 some crates don't use 6 digit subsecond timestamps.

crates.io internally uses chrono, which changed how they represented their rfc3339 timestamps.

So, we use time's rfc3339 serde support to match it.