### PR TITLE
bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-whatfeatures"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "attohttpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-whatfeatures"
 readme = "README.md"
 repository = "https://github.com/museun/cargo-whatfeatures"
-version = "0.9.11"
+version = "0.9.12"
 
 [[bin]]
 name = "cargo-whatfeatures"


### PR DESCRIPTION
This version allows `--manifest-path Cargo.toml` to be used as intended.